### PR TITLE
fix(generate): Forcing the PK to be not nullable

### DIFF
--- a/pkg/models/table.go
+++ b/pkg/models/table.go
@@ -61,6 +61,7 @@ func (t *Table) setPrimaryKey(con *ast.Constraint) {
 		t.PrimaryKey.Columns[i].InUniqueKey = true
 	}
 
+	// TODO: remove this once the parser is fixed
 	for _, col := range t.Columns {
 		for _, pk := range t.PrimaryKey.Columns {
 			if col.Name == pk.Name {

--- a/pkg/models/table.go
+++ b/pkg/models/table.go
@@ -60,6 +60,16 @@ func (t *Table) setPrimaryKey(con *ast.Constraint) {
 		t.PrimaryKey.Columns[i].InPrimaryKey = true
 		t.PrimaryKey.Columns[i].InUniqueKey = true
 	}
+
+	for _, col := range t.Columns {
+		for _, pk := range t.PrimaryKey.Columns {
+			if col.Name == pk.Name {
+				col.InPrimaryKey = true
+				col.InUniqueKey = true
+				col.Nullable = false
+			}
+		}
+	}
 }
 
 func (t *Table) addKey(con *ast.Constraint) {

--- a/pkg/models/table.go
+++ b/pkg/models/table.go
@@ -61,7 +61,7 @@ func (t *Table) setPrimaryKey(con *ast.Constraint) {
 		t.PrimaryKey.Columns[i].InUniqueKey = true
 	}
 
-	// TODO: remove this once the parser is fixed
+	// Enforce all PK columns to be NOT NULL
 	for _, col := range t.Columns {
 		for _, pk := range t.PrimaryKey.Columns {
 			if col.Name == pk.Name {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->
 This saves having to explicitly set the PK to not be null when all PKs are not allowed to be null by default