### PR TITLE
feat(templates): adding timer metric to the patch templates

### DIFF
--- a/templates/_update.tmpl
+++ b/templates/_update.tmpl
@@ -32,6 +32,9 @@ func (m *{{ $struct }}) Patch(db DB, newT *{{ $struct }}) error {
         return errors.New("new {{ .Name }} is nil")
     }
 
+    t := prometheus.NewTimer(DatabaseLatency.WithLabelValues("patch_" + {{ $struct }}TableName))
+    defer t.ObserveDuration()
+
 	res, err := patcher.NewDiffSQLPatch(m, newT, patcher.WithTable({{ $struct | structify -}}TableName))
 	if err != nil {
 		return fmt.Errorf("new diff sql patch: %w", err)


### PR DESCRIPTION
This pull request introduces a performance monitoring enhancement to the `Patch` method in the `templates/_update.tmpl` file. The most important change is the addition of Prometheus instrumentation to measure the latency of the database patch operation.

Performance monitoring enhancement:

* [`templates/_update.tmpl`](diffhunk://#diff-8c65936f2dbc8ccbc9e7b5e4b7349e3029cb1153321a19554512b4fd54438f8bR35-R37): Added Prometheus timer to measure and observe the duration of the `Patch` method execution.