### PR TITLE
fix(templates): correcting when we can patch in the templates

### DIFF
--- a/templates/_update.tmpl
+++ b/templates/_update.tmpl
@@ -26,37 +26,4 @@ func (m *{{ $struct }}) Update(db DB) error {
 
     return nil
 }
-
-func (m *{{ $struct }}) Patch(db DB, newT *{{ $struct }}) error {
-    if newT == nil {
-        return errors.New("new {{ .Name }} is nil")
-    }
-
-    t := prometheus.NewTimer(DatabaseLatency.WithLabelValues("patch_" + {{ $struct }}TableName))
-    defer t.ObserveDuration()
-
-	res, err := patcher.NewDiffSQLPatch(m, newT, patcher.WithTable({{ $struct | structify -}}TableName))
-	if err != nil {
-		switch {
-    	case errors.Is(err, patcher.ErrNoChanges):
-    		return nil
-    	default:
-    		return fmt.Errorf("new diff sql patch: %w", err)
-    	}
-	}
-
-	sqlstr, args, err := res.GenerateSQL()
-	if err != nil {
-	    return fmt.Errorf("failed to generate patch: %w", err)
-	}
-
-	DBLog(sqlstr, args...)
-	_, err = db.Exec(sqlstr, args...)
-	if err != nil {
-		return fmt.Errorf("failed to execute patch: %w", err)
-	}
-
-	return nil
-}
-
 {{- end -}}

--- a/templates/model.tmpl
+++ b/templates/model.tmpl
@@ -111,11 +111,11 @@ func {{ $struct }}By{{ range $i, $col := $key.Columns }}{{ $col.Name | structify
 	return &m, nil
 }
 
-type {{ lcfirst $struct }}IdWherer struct {
+type {{ lcfirst $struct }}PKWherer struct {
     ids []interface{}
 }
 
-func (m {{ lcfirst $struct }}IdWherer) Where() (string, []interface{}) {
+func (m {{ lcfirst $struct }}PKWherer) Where() (string, []interface{}) {
     return "{{ range $i, $col := $key.Columns }}{{ if $i }} AND {{ end }}`{{ $col.Name }}` = ?{{ end }}", m.ids
 }
 
@@ -134,7 +134,7 @@ func (m *{{ $struct }}) Patch(db DB, newT *{{ $struct }}) error {
 	    m,
 	    newT,
 	    patcher.WithTable({{ $struct }}TableName),
-	    patcher.WithWhere(&{{ lcfirst $struct }}IdWherer{
+	    patcher.WithWhere(&{{ lcfirst $struct }}PKWherer{
 	        ids: []interface{}{ {{ range $i, $col := $key.Columns }}m.{{ $col.Name | structify }},{{ end }} },
 	    }),
 	)

--- a/templates/model.tmpl
+++ b/templates/model.tmpl
@@ -110,6 +110,56 @@ func {{ $struct }}By{{ range $i, $col := $key.Columns }}{{ $col.Name | structify
 
 	return &m, nil
 }
+
+type {{ lcfirst $struct }}IdWherer struct {
+    ids []interface{}
+}
+
+func (m {{ lcfirst $struct }}IdWherer) Where() (string, []interface{}) {
+    return "{{ range $i, $col := $key.Columns }}{{ if $i }} AND {{ end }}`{{ $col.Name }}` = ?{{ end }}", m.ids
+}
+
+// Patch updates the {{ $struct }} in the database.
+//
+// Generated from primary key.
+func (m *{{ $struct }}) Patch(db DB, newT *{{ $struct }}) error {
+    if newT == nil {
+        return errors.New("new {{ .Name }} is nil")
+    }
+
+    t := prometheus.NewTimer(DatabaseLatency.WithLabelValues("patch_" + {{ $struct }}TableName))
+    defer t.ObserveDuration()
+
+	res, err := patcher.NewDiffSQLPatch(
+	    m,
+	    newT,
+	    patcher.WithTable({{ $struct }}TableName),
+	    patcher.WithWhere(&{{ lcfirst $struct }}IdWherer{
+	        ids: []interface{}{ {{ range $i, $col := $key.Columns }}m.{{ $col.Name | structify }},{{ end }} },
+	    }),
+	)
+	if err != nil {
+		switch {
+    	case errors.Is(err, patcher.ErrNoChanges):
+    		return nil
+    	default:
+    		return fmt.Errorf("new diff sql patch: %w", err)
+    	}
+	}
+
+	sqlstr, args, err := res.GenerateSQL()
+	if err != nil {
+	    return fmt.Errorf("failed to generate patch: %w", err)
+	}
+
+	DBLog(sqlstr, args...)
+	_, err = db.Exec(sqlstr, args...)
+	if err != nil {
+		return fmt.Errorf("failed to execute patch: %w", err)
+	}
+
+	return nil
+}
 {{ range $constraint := $.Table.Constraints -}}
 {{ $constraint_ref_len := len $constraint.References }}
 {{ if eq $constraint_ref_len 1 -}}


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request makes significant updates to the patch functionality in the codebase, including the addition of a new `Patch` method and the removal of the old one. The changes enhance the way patches are generated and executed in the database.

Enhancements to patch functionality:

* [`templates/_update.tmpl`](diffhunk://#diff-8c65936f2dbc8ccbc9e7b5e4b7349e3029cb1153321a19554512b4fd54438f8bL29-L61): Removed the old `Patch` method, which handled patching by generating and executing SQL patches.
* [`templates/model.tmpl`](diffhunk://#diff-3376c7f40673ce75f47c599b243f43e01b287bc01c32d8abe5eb053d0c27a179R113-R162): Added a new `Patch` method that includes a `{{ lcfirst $struct }}IdWherer` type for generating the `WHERE` clause based on primary key columns. This method also uses the `patcher.NewDiffSQLPatch` function to create SQL patches.