### PR TITLE
fix(templates): ignoreing the primary key when patching

### DIFF
--- a/templates/model.tmpl
+++ b/templates/model.tmpl
@@ -137,6 +137,11 @@ func (m *{{ $struct }}) Patch(db DB, newT *{{ $struct }}) error {
 	    patcher.WithWhere(&{{ lcfirst $struct }}PKWherer{
 	        ids: []interface{}{ {{ range $i, $col := $key.Columns }}m.{{ $col.Name | structify }},{{ end }} },
 	    }),
+	    patcher.WithIgnoredFields(
+	        {{- range $i, $col := $key.Columns }}
+	        "{{ $col.Name | structify }}",
+	        {{- end}}
+	    ),
 	)
 	if err != nil {
 		switch {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request involves a change to the `Patch` method in the `templates/model.tmpl` file. The change adds a feature to ignore certain fields during the patch operation.

### Changes to Patch Method:

* [`templates/model.tmpl`](diffhunk://#diff-3376c7f40673ce75f47c599b243f43e01b287bc01c32d8abe5eb053d0c27a179R140-R144): Added `patcher.WithIgnoredFields` to the `Patch` method to specify which fields should be ignored during the patch operation. This ensures that primary key fields are not updated.