### PR TITLE
fix(types): fixing type mismatch

### DIFF
--- a/pkg/entities/column.go
+++ b/pkg/entities/column.go
@@ -39,6 +39,9 @@ type Column struct {
 
 func (c *Column) setTypeInfo(tp *types.FieldType) {
 	c.Type = tp.EvalType().String()
+	if tp.GetType() == mysql.TypeLonglong {
+		c.Type = "bigint"
+	}
 	c.TypeSize = tp.GetFlen()
 	c.TypePrecision = tp.GetDecimal()
 	if tp.GetType() == mysql.TypeEnum {
@@ -85,7 +88,7 @@ func (c *Column) setOptions(col *ast.ColumnDef) error {
 			c.InUniqueKey = true
 		default:
 			// Ignore other options
-			slog.Warn("Unknown column option", slog.Int("type", int(opt.Tp)))
+			slog.Warn("Unhandled column option", slog.Int("type", int(opt.Tp)))
 		}
 	}
 	return nil

--- a/pkg/generation/template_helpers.go
+++ b/pkg/generation/template_helpers.go
@@ -257,6 +257,8 @@ func getType(col *entities.Column) string {
 			return "usql.NullDuration"
 		}
 		return "usql.Duration"
+	case "json":
+		return "json.RawMessage"
 	default:
 		fmt.Println("Unknown type:", col.Type)
 		return "unknown"

--- a/templates/model.tmpl
+++ b/templates/model.tmpl
@@ -28,7 +28,10 @@ const (
 {{- end }}
 type {{ $struct }} struct {
 	{{ range $column := .Columns -}}
-	{{ .Name | structify }} {{ get_type $column }} {{ get_tags $column }} {{ if .Comment }}// {{ .Comment }}{{ end }}
+	{{- if .Comment -}}
+	// {{ .Comment }}
+	{{- end -}}
+	{{ .Name | structify }} {{ get_type $column }} {{ get_tags $column }}
 	{{ end -}}
 }
 
@@ -182,7 +185,7 @@ func (m *{{ $struct }}) Get{{ $local_col | structify }}{{ $foreign_struct }}(db 
   }
 
   {{ end -}}
-	return {{ $foreign_struct }}By{{ $foreign_col | structify }}(db, m.{{ $local_col | structify }}{{ if $col_data.Nullable }}.{{ get_type $col_data }}{{ end }})
+	return {{ $foreign_struct }}By{{ $foreign_col | structify }}(db, m.{{ $local_col | structify }}{{ if $col_data.Nullable }}.Val(){{ end }})
 }
 {{ end -}}
 {{ end -}}

--- a/usql/types.go
+++ b/usql/types.go
@@ -19,7 +19,7 @@ type NullBool struct {
 }
 
 // MarshalJSON implements the json.Marshaler interface for a NullBool.
-func (r NullBool) MarshalJSON() ([]byte, error) {
+func (r *NullBool) MarshalJSON() ([]byte, error) {
 	if r.Valid {
 		return json.Marshal(r.Bool)
 	}
@@ -42,6 +42,10 @@ func (r *NullBool) UnmarshalJSON(data []byte) error {
 	r.Valid = true
 
 	return nil
+}
+
+func (r NullBool) Val() bool {
+	return r.Bool
 }
 
 // NewNullBool returns a valid new NullBool for a given boolean value.
@@ -80,6 +84,10 @@ func (r *NullFloat64) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *NullFloat64) Val() float64 {
+	return r.Float64
+}
+
 // NewNullFloat64 returns a valid new NullFloat64 for a given float64 value.
 func NewNullFloat64(f float64) *NullFloat64 {
 	return &NullFloat64{NullFloat64: sql.NullFloat64{Float64: f, Valid: true}}
@@ -114,6 +122,10 @@ func (r *NullInt64) UnmarshalJSON(data []byte) error {
 	r.Valid = true
 
 	return nil
+}
+
+func (r NullInt64) Val() int64 {
+	return r.Int64
 }
 
 // RedisArg implements redis.Argument.
@@ -183,6 +195,10 @@ func (r *NullString) UnmarshalJSON(data []byte) error {
 	r.Valid = true
 
 	return nil
+}
+
+func (r NullString) Val() string {
+	return r.String
 }
 
 // RedisArg implements redis.Argument.
@@ -305,6 +321,10 @@ type NullDuration struct {
 	Valid bool
 }
 
+func (r NullDuration) Val() time.Duration {
+	return time.Duration(r.Duration)
+}
+
 // MarshalJSON implements the json.Marshaler interface for a NullDuration.
 func (r NullDuration) MarshalJSON() ([]byte, error) {
 	if r.Valid {
@@ -339,6 +359,11 @@ func NewNullDuration(t time.Duration) *NullDuration {
 // sql.Scanner, and sql/driver.Valuer interfaces.
 type NullTime struct {
 	sql.NullTime
+}
+
+// Val returns the time.Time value of the NullTime.
+func (r NullTime) Val() time.Time {
+	return r.Time
 }
 
 // MarshalJSON implements json.Marshaller.


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes across multiple files to improve type handling, logging, and JSON marshaling. The most important changes include adding new methods to retrieve values from nullable types, updating type handling for specific MySQL types, and improving logging messages.

### Type Handling Improvements:
* [`pkg/entities/column.go`](diffhunk://#diff-f453dd2fd61c80737e1c25b5d67486f92d7eebddfdafbc3ce26079cdbdd478dbR42-R44): Added handling for `bigint` type in the `setTypeInfo` method.
* [`pkg/generation/template_helpers.go`](diffhunk://#diff-86493be4c5fbc2a261cda754725500e89561b886ae0b8244f30baeb570b935edR260-R261): Added support for `json.RawMessage` in the `getType` function.

### Logging Improvements:
* [`pkg/entities/column.go`](diffhunk://#diff-f453dd2fd61c80737e1c25b5d67486f92d7eebddfdafbc3ce26079cdbdd478dbL88-R91): Updated the warning message for unhandled column options in the `setOptions` method.

### Template Adjustments:
* [`templates/model.tmpl`](diffhunk://#diff-3376c7f40673ce75f47c599b243f43e01b287bc01c32d8abe5eb053d0c27a179L31-R34): Adjusted the model template to properly handle comments and nullable types. [[1]](diffhunk://#diff-3376c7f40673ce75f47c599b243f43e01b287bc01c32d8abe5eb053d0c27a179L31-R34) [[2]](diffhunk://#diff-3376c7f40673ce75f47c599b243f43e01b287bc01c32d8abe5eb053d0c27a179L185-R188)

### Nullable Type Enhancements:
* [`usql/types.go`](diffhunk://#diff-8677e2e73d40ea5c237e3b373e12e430f9043b6e62ac92cc4e66d215b07e48f9R47-R50): Added `Val` methods to various nullable types (`NullBool`, `NullFloat64`, `NullInt64`, `NullString`, `NullDuration`, `NullTime`) to retrieve their values. [[1]](diffhunk://#diff-8677e2e73d40ea5c237e3b373e12e430f9043b6e62ac92cc4e66d215b07e48f9R47-R50) [[2]](diffhunk://#diff-8677e2e73d40ea5c237e3b373e12e430f9043b6e62ac92cc4e66d215b07e48f9R87-R90) [[3]](diffhunk://#diff-8677e2e73d40ea5c237e3b373e12e430f9043b6e62ac92cc4e66d215b07e48f9R127-R130) [[4]](diffhunk://#diff-8677e2e73d40ea5c237e3b373e12e430f9043b6e62ac92cc4e66d215b07e48f9R200-R203) [[5]](diffhunk://#diff-8677e2e73d40ea5c237e3b373e12e430f9043b6e62ac92cc4e66d215b07e48f9R324-R327) [[6]](diffhunk://#diff-8677e2e73d40ea5c237e3b373e12e430f9043b6e62ac92cc4e66d215b07e48f9R364-R368)