### PR TITLE
fix(types): Updating type casting to bools

### DIFF
--- a/pkg/entities/column.go
+++ b/pkg/entities/column.go
@@ -38,9 +38,17 @@ type Column struct {
 }
 
 func (c *Column) setTypeInfo(tp *types.FieldType) {
-	c.Type = tp.EvalType().String()
-	if tp.GetType() == mysql.TypeLonglong {
+	switch {
+	case tp.GetType() == mysql.TypeTiny:
+		c.Type = "tinyint"
+	case tp.GetType() == mysql.TypeShort:
+		c.Type = "smallint"
+	case tp.GetType() == mysql.TypeInt24:
+		c.Type = "mediumint"
+	case tp.GetType() == mysql.TypeLonglong:
 		c.Type = "bigint"
+	default:
+		c.Type = tp.EvalType().String()
 	}
 	c.TypeSize = tp.GetFlen()
 	c.TypePrecision = tp.GetDecimal()


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a change to the `setTypeInfo` method in the `Column` struct within the `pkg/entities/column.go` file. The change involves refining the logic for setting the column type based on the MySQL field type.

Improvements to type setting logic:

* [`pkg/entities/column.go`](diffhunk://#diff-f453dd2fd61c80737e1c25b5d67486f92d7eebddfdafbc3ce26079cdbdd478dbL41-R51): Updated the `setTypeInfo` method to use a `switch` statement for more precise type assignments, specifically handling `mysql.TypeTiny`, `mysql.TypeShort`, and `mysql.TypeInt24` to set the column types to "tinyint", "smallint", and "mediumint" respectively. The default case falls back to using the `EvalType` method.