### PR TITLE
fix(templates): updating templates to check cast was okay and prevent panic

### DIFF
--- a/pkg/models/db.xo.go
+++ b/pkg/models/db.xo.go
@@ -23,8 +23,8 @@ type DB interface {
 	Exec(string, ...any) (sql.Result, error)
 	Query(string, ...any) (*sql.Rows, error)
 	QueryRow(string, ...any) *sql.Row
-	Get(dest any, query string, args ...interface{}) error
-	Select(dest any, query string, args ...interface{}) error
+	Get(dest any, query string, args ...any) error
+	Select(dest any, query string, args ...any) error
 }
 
 // Transactioner is the interface that a database connection that can start

--- a/pkg/models/helpers.xo.go
+++ b/pkg/models/helpers.xo.go
@@ -97,7 +97,7 @@ func NewLoggableDBTransactionHandler(db Transactioner, l *slog.Logger) *Loggable
 // 1. x is an integer and greater than zero.
 // 2. x not an integer and is not the zero value.
 // Otherwise, returns false
-func IsKeySet(x interface{}) bool {
+func IsKeySet(x any) bool {
 	switch x := x.(type) {
 	case int:
 		return x > 0

--- a/templates/model.tmpl
+++ b/templates/model.tmpl
@@ -229,11 +229,12 @@ func GetAll{{ $struct }}s(db DB, filters ...any) ([]*{{ $struct }}, error) {
 
     args := make([]any, 0)
     builder := new(strings.Builder)
-    builder.WriteString("SELECT {{ range $i, $column := $.Table.Columns }}{{ if $i }}, {{ end }}`t.{{ $column.Name }}`{{ end }}")
+    builder.WriteString("SELECT {{ range $i, $column := $.Table.Columns }}{{ if $i }}, {{ end }}t.{{ $column.Name }}{{ end }}")
 
     if len(filters) > 0 {
         for _, filter := range filters {
-            if joiner := filter.(patcher.Joiner); joiner != nil {
+            joiner, ok := filter.(patcher.Joiner)
+            if ok {
                 joinSql, joinArgs := joiner.Join()
                 builder.WriteString(joinSql)
                 args = append(args, joinArgs...)
@@ -246,7 +247,8 @@ func GetAll{{ $struct }}s(db DB, filters ...any) ([]*{{ $struct }}, error) {
     if len(filters) > 0 {
         builder.WriteString("\nWHERE\n")
         for i, filter := range filters {
-            if where := filter.(patcher.Wherer); where != nil {
+            where, ok := filter.(patcher.Wherer)
+            if ok {
                 if i > 0 {
             		wtStr := patcher.WhereTypeAnd
             		if wt, ok := filter.(patcher.WhereTyper); ok {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes improvements to the `GetAll` function in the `templates/model.tmpl` file. The changes enhance the robustness of type assertions and simplify the code structure.

Enhancements to type assertions:

* [`templates/model.tmpl`](diffhunk://#diff-3376c7f40673ce75f47c599b243f43e01b287bc01c32d8abe5eb053d0c27a179L232-R237): Modified the type assertion for `patcher.Joiner` to use a two-value assignment for better error handling.
* [`templates/model.tmpl`](diffhunk://#diff-3376c7f40673ce75f47c599b243f43e01b287bc01c32d8abe5eb053d0c27a179L249-R251): Modified the type assertion for `patcher.Wherer` to use a two-value assignment for better error handling.