### PR TITLE
feat(cicd): adding type assert linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - intrange
     - testifylint
     - perfsprint
+    - forcetypeassert
 issues:
   exclude-rules:
     - path: (.+)_test.go

--- a/pkg/generation/templates.go
+++ b/pkg/generation/templates.go
@@ -135,7 +135,13 @@ func renderHelpers(fs embed.FS, outputLoc, fileExtensionPrefix string) error {
 
 	errs.Range(func(key, value any) bool {
 		if value != nil {
-			slog.Error("Error rendering helpers", slog.String(logging.KeyError, value.(error).Error()))
+			valErr, ok := value.(error)
+			if !ok {
+				slog.Error("Error rendering helpers", slog.String(logging.KeyError, "error not of type error"))
+				return true
+			}
+
+			slog.Error("Error rendering helpers", slog.String(logging.KeyError, valErr.Error()))
 		}
 
 		return true

--- a/usql/datetime.go
+++ b/usql/datetime.go
@@ -1,6 +1,7 @@
 package usql
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
@@ -41,15 +42,25 @@ func (d *DateTime) Scan(src any) error {
 	case time.Time:
 		*d = DateTime{t}
 	case string:
+		srcStr, ok := src.(string)
+		if !ok {
+			return errors.New("string type assertion failed")
+		}
+
 		// Parse the time.
-		parsedT, err := time.Parse(time.RFC3339, src.(string))
+		parsedT, err := time.Parse(time.RFC3339, srcStr)
 		if err != nil {
 			return fmt.Errorf("%s is not in the RFC3339 format", t)
 		}
 		*d = DateTime{parsedT}
 	case []uint8:
+		sliceStr, ok := src.([]uint8)
+		if !ok {
+			return errors.New("[]uint8 type assertion failed")
+		}
+
 		// Parse the time.
-		parsedT, err := time.Parse(time.DateTime, string(src.([]uint8)))
+		parsedT, err := time.Parse(time.DateTime, string(sliceStr))
 		if err != nil {
 			return fmt.Errorf("%s is not in the RFC3339 format", t)
 		}


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to the `.golangci.yaml` configuration file and improvements to error handling in `pkg/generation/templates.go`.

Configuration updates:
* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R18): Added `forcetypeassert` to the list of linters.

Error handling improvements:
* [`pkg/generation/templates.go`](diffhunk://#diff-da69e6e77b85fd73779812de937b6267c62b19494fa6a674730ee7415c79beebL138-R144): Improved error handling in the `renderHelpers` function by adding type assertion and logging when the value is not of type `error`.