### PR TITLE
fix(migrate): fixing the ordering of files from early return

### DIFF
--- a/pkg/migrations/up.go
+++ b/pkg/migrations/up.go
@@ -216,7 +216,6 @@ func orderFiles(files []os.DirEntry) ([]os.DirEntry, error) {
 				continue
 			}
 			ordered = append(ordered, f)
-			return ordered, nil
 		}
 	}
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a small change to the `pkg/migrations/up.go` file. The change removes an incorrect early return statement in the `orderFiles` function to ensure that all files are processed before returning the ordered list. 

* [`pkg/migrations/up.go`](diffhunk://#diff-cbc92e9fe9aac04447f39e1cc023787a27b4662f3d21ab323e451927902ec486L219): Removed an erroneous `return ordered, nil` statement inside the loop to allow the function to process all files correctly.