### PR TITLE
fix(create): correcting the generation of the naming for the down scripts

### DIFF
--- a/cmd_create.go
+++ b/cmd_create.go
@@ -80,7 +80,7 @@ func (c *createCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...any) subcom
 	name = strings.ReplaceAll(name, " ", "_")
 
 	upName := name + ".up.sql"
-	downName := name + "%s.down.sql"
+	downName := name + ".down.sql"
 
 	upPath := fmt.Sprintf("%s/%s", c.outputLocation, upName)
 	downPath := fmt.Sprintf("%s/%s", c.outputLocation, downName)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a small change to the `cmd_create.go` file. The change corrects the format string for the `downName` variable to ensure it matches the format used for `upName`.

* [`cmd_create.go`](diffhunk://#diff-c58acaae4ae412b492a5b0a879037da7da4a60d2a0583623ad2707282811c179L83-R83): Changed the `downName` format string from `name + "%s.down.sql"` to `name + ".down.sql"`.