### PR TITLE
feat(templates): adding insert with pk ability

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -1,5 +1,4 @@
 //go:build mage
-// +build mage
 
 package main
 

--- a/templates/_insert.tmpl
+++ b/templates/_insert.tmpl
@@ -32,6 +32,26 @@ func (m *{{ $struct }}) Insert(db DB) error {
     {{- end }}
 }
 
+func (m *{{ $struct }}) Insert{{ $struct }}WithPK(db DB) error {
+    if !m.IsPrimaryKeySet() {
+        return ErrNoPK
+    }
+
+    t := prometheus.NewTimer(DatabaseLatency.WithLabelValues("insert_with_ids_" + {{ $struct | structify }}TableName))
+    defer t.ObserveDuration()
+
+    {{ $cols := .Columns -}}
+    const sqlstr = "INSERT INTO {{ .Name }} (" +
+        "{{ range $i, $column := $cols }}{{ if $i }}, {{ end }}`{{ $column.Name }}`{{ end }}" +
+        ") VALUES (" +
+        "{{ range $i, $column := $cols }}{{ if $i }}, {{ end }}?{{ end }}" +
+        ")"
+
+    DBLog(sqlstr, {{ range $i, $column := $cols }}{{ if $i }}, {{ end }}m.{{ $column.Name | structify }}{{ end }})
+    _, err := db.Exec(sqlstr, {{ range $i, $column := $cols }}{{ if $i }}, {{ end }}m.{{ $column.Name | structify }}{{ end }})
+    return err
+}
+
 func InsertMany{{ $struct }}s(db DB, ms ...*{{ $struct }}) error {
     if len(ms) == 0 {
         return nil

--- a/templates/helpers.tmpl
+++ b/templates/helpers.tmpl
@@ -9,6 +9,11 @@ import (
 	"reflect"
 )
 
+var (
+    // ErrNoPK is returned when a primary key is not set.
+    ErrNoPK = errors.New("primary key is not set")
+)
+
 // Saveable is the interface implemented by types which can save themselves to the database.
 type Saveable interface {
 	Save(db DB) error


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces several changes to improve error handling and add a new insert function with primary key validation in the database templates. Below are the most important changes:

### Error Handling Improvements:
* [`templates/helpers.tmpl`](diffhunk://#diff-1855abd2295fba7d8325b79d2744fe7d998a76352d872ce32fb73afbbef82a64R12-R16): Added a new error variable `ErrNoPK` to handle cases where the primary key is not set.

### New Insert Function:
* [`templates/_insert.tmpl`](diffhunk://#diff-d98e0fd9906fb039ab3f47ae2224c53838c30d69f785bb131cbfa997d1f8c46eR35-R54): Added a new function `Insert{{ $struct }}WithPK` to insert records into the database with primary key validation. This function checks if the primary key is set before performing the insert operation and logs the SQL query.

### Code Cleanup:
* [`magefile.go`](diffhunk://#diff-520109d035a196d29d0a86e9c4e6c98e98abf056141b84df68c0d48167b87b25L2): Removed the unnecessary build tag `+build mage` to clean up the file.